### PR TITLE
Add lookup option "skblen" and "gso_size"

### DIFF
--- a/cmd/lookup.go
+++ b/cmd/lookup.go
@@ -47,6 +47,7 @@ type lookupIn struct {
 	TableID      *uint32
 	Mark         *uint32
 	SkbLen       uint32
+	GsoSize      uint32
 }
 
 func (in *lookupIn) marshal() []byte {
@@ -372,13 +373,29 @@ var lookupCmd = &cobra.Command{
 			return
 		}
 
+		// We don't need to attach the program to any interface. Just
+		// run it should be sufficient to test the bpf_fib_lookup.
 		skbLen := 64
 		if in.SkbLen != 0 {
 			skbLen = int(in.SkbLen)
 		}
-		// We don't need to attach the program to any interface. Just
-		// run it should be sufficient to test the bpf_fib_lookup.
-		uret, _, err := col.Programs["lookup"].Test(bytes.Repeat([]byte{0xff}, skbLen))
+		context := make([]byte, 256)
+		if in.GsoSize != 0 {
+			offset, size, err := MemberOfSkBuff("gso_size")
+			if err != nil {
+				cmd.PrintErrf("Failed to get offset of gso_size: %s\n\n", err)
+				return
+			}
+			binary.NativeEndian.PutUint32(context[offset:offset+size], in.GsoSize)
+		}
+		runOptions := &ebpf.RunOptions{
+			Data: bytes.Repeat([]byte{0xff}, skbLen),
+			// https://github.com/cilium/ebpf/blob/20c4d8896bdde990ce6b80d59a4262aa3ccb891d/prog.go#L563-L567
+			DataOut:    make([]byte, skbLen+256+2),
+			Context:    context,
+			ContextOut: make([]byte, 256),
+		}
+		uret, err := col.Programs["lookup"].Run(runOptions)
 		if err != nil {
 			cmd.PrintErrf("Failed to run program: %s\n\n", err)
 			return
@@ -591,6 +608,20 @@ var lookupCmdOpts = map[string]lookupOpt{
 				return 0, fmt.Errorf("cannot parse skblen: %w", err)
 			}
 			in.SkbLen = uint32(skblen)
+			return 1, nil
+		},
+	},
+	"gso_size": {
+		desc: []string{"gso_size", "<gso_size>", "skb_shinfo(skb)->gso_size"},
+		handle: func(in *lookupIn, args []string) (int, error) {
+			if len(args) == 0 {
+				return 0, fmt.Errorf("gso_size is unspecified")
+			}
+			gsoSize, err := strconv.ParseUint(args[0], 10, 32)
+			if err != nil {
+				return 0, fmt.Errorf("cannot parse gso_size: %w", err)
+			}
+			in.GsoSize = uint32(gsoSize)
 			return 1, nil
 		},
 	},

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/cilium/ebpf/btf"
+)
+
+var (
+	skBuffMembers map[string][2]uint32
+	parseOnce     sync.Once
+)
+
+func parseSkbBuffMembers() error {
+	btfSpec, err := btf.LoadKernelSpec()
+	if err != nil {
+		return fmt.Errorf("failed to load kernel BTF: %w", err)
+	}
+
+	iter := btfSpec.Iterate()
+	for iter.Next() {
+
+		if strct, ok := iter.Type.(*btf.Struct); ok && strct.Name == "__sk_buff" {
+			fields := make(map[string][2]uint32)
+
+			for _, member := range strct.Members {
+				offsetInBytes := member.Offset.Bytes()
+				SizeInBytes, err := btf.Sizeof(member.Type)
+				if err != nil {
+					return fmt.Errorf("failed to get size of member '%s': %w", member.Name, err)
+				}
+				fields[member.Name] = [2]uint32{uint32(offsetInBytes), uint32(SizeInBytes)}
+			}
+
+			skBuffMembers = fields
+			return nil
+		}
+	}
+
+	return fmt.Errorf("__sk_buff struct not found in kernel BTF")
+}
+
+func MemberOfSkBuff(field string) (offset, size uint32, err error) {
+	parseOnce.Do(func() {
+		err = parseSkbBuffMembers()
+	})
+
+	if err != nil {
+		return 0, 0, err
+	}
+
+	member, ok := skBuffMembers[field]
+	if !ok {
+		return 0, 0, fmt.Errorf("field '%s' not found in __sk_buff struct", field)
+	}
+
+	return member[0], member[1], nil
+}


### PR DESCRIPTION
bpf_fib_lookup could run into a mtu check `is_skb_forwardable`[1], where skb->len and skb_shinfo(skb)->gso_size is essential.

By adding the two options, we can reproduce fib lookup errors more easily.

```
$ ./bpfib lookup 1.1.1.1 lo skblen 2000 
Fragmentation Needed (BPF_FIB_LKUP_RET_FRAG_NEEDED) mtu 1500

$ ./bpfib lookup 1.1.1.1 lo skblen 2000 gso_size 2000
1.1.1.1 dev enp0s31f6 mtu 1500 metric 100
```

[1]: [1]: https://elixir.bootlin.com/linux/v6.12.30/source/net/core/filter.c#L6280