### PR TITLE
Reset BPF_FIB_LOOKUP_DIRECT if mark is specified

### DIFF
--- a/cmd/lookup.go
+++ b/cmd/lookup.go
@@ -311,6 +311,12 @@ var lookupCmd = &cobra.Command{
 		if src, _ := cmd.Flags().GetBool("src"); src {
 			flags |= BFP_FIB_LOOKUP_SRC
 		}
+		if in.Mark != nil {
+			if flags&BPF_FIB_LOOKUP_DIRECT != 0 {
+				cmd.PrintErrf("Forcefully resetting BFP_FIB_LOOKUP_DIRECT option since you specified mark option which should not be used with direct lookup. To suppress this message, don't set --direct flag.\n")
+				flags &^= BFP_FIB_LOOKUP_DIRECT
+			}
+		}
 
 		// Serialize input parameters to write struct bpf_fib_lookup to map
 		param := in.marshal()


### PR DESCRIPTION
The mark only has meaning for full lookups[^1]. Reset BPF_FIB_LOOKUP_DIRECT and emit a warning if a mark is present.

[^1]: https://github.com/torvalds/linux/blob/546b1c9e93c2bb8cf5ed24e0be1c86bb089b3253/include/uapi/linux/bpf.h#L3422-L3425